### PR TITLE
Add Optional Callback Support to Spinner and ProgressBar

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ func main() {
 
 ### Spinners
 
-You can customize the spinner’s message, colors, speed and theme, etc...:
+You can customize the spinner's message, colors, speed, theme and define a custom callback function that will run once the and spinner is completed:
 
 ```go
 func main() {
@@ -108,7 +108,10 @@ func main() {
 		SetMessageColor("\033[33m").
 		SetCustomTheme([]string{"▁", "▃", "▄", "▅", "▆", "▇", "█", "▇", "▆", "▅", "▄", "▃"}).
 		SetSpinnerColor("\033[31m"). // Red color (you can use every color you want with that format but spinner color will not work with emoji spinner)
-		SetSpeed(200 * time.Millisecond)
+		SetSpeed(200 * time.Millisecond).
+		SetCallback(func() {
+			fmt.Println("The callback function has executed!")
+		})
 
 	spinner.Start()
 	time.Sleep(2 * time.Second) // Simulate a task
@@ -118,7 +121,7 @@ func main() {
 
 ### Progress Bars
 
-You can customize the progress bar's message, width, color, appearance using various methods and etc...:
+You can customize the progress bar's message, width, color, appearance and define a custom callback function that will run once the and progress bar is completed:
 
 ```go
 func main() {
@@ -127,7 +130,10 @@ func main() {
 		SetBarChar("█").
 		SetEmptyChar("░").
 		SetBorders("[", "]").
-		SetShowPercentage(true)
+		SetShowPercentage(true).
+		SetCallback(func() {
+			fmt.Println("The callback function has executed!")
+		})
 
 	progressBar.Start()
 

--- a/spinix.go
+++ b/spinix.go
@@ -20,6 +20,7 @@ type Spinner struct {
 	active       bool          // Status for loading indicator
 	mutex        sync.Mutex    // For thread-safe operations
 	stopCh       chan struct{} // Channel to send stop signal
+	callback     func()        // Optional callback to run after spinner stops
 }
 
 // NewSpinner initializes a new Spinner with default settings and theme.
@@ -32,6 +33,12 @@ func NewSpinner() *Spinner {
 		showMessage:  true,
 		stopCh:       make(chan struct{}),
 	}
+}
+
+// SetCallback sets a callback function to be executed when the spinner stops.
+func (s *Spinner) SetCallback(cb func()) *Spinner {
+	s.callback = cb
+	return s
 }
 
 // Start begins the spinner animation in a goroutine.
@@ -58,6 +65,11 @@ func (s *Spinner) Stop() {
 	s.stopCh = make(chan struct{})
 	s.active = false
 	fmt.Print("\r\033[K") // Clear line
+
+	// Execute callback if set
+	if s.callback != nil {
+		s.callback()
+	}
 }
 
 // SetMessageColor sets the color code for the spinner's message text.
@@ -197,6 +209,7 @@ type ProgressBar struct {
 	active         bool             // Indicates if the progress bar is active
 	mutex          sync.Mutex       // For thread safety
 	stopCh         chan interface{} // Channel to signal stopping of the progress bar
+	callback       func()           // Optional callback to run after progress bar stops
 }
 
 // NewProgressBar initializes a new ProgressBar with default settings.
@@ -212,6 +225,12 @@ func NewProgressBar() *ProgressBar {
 		stopCh:         make(chan interface{}),
 		speed:          100 * time.Millisecond,
 	}
+}
+
+// SetCallback sets a callback function to be executed when the progress bar stops.
+func (pb *ProgressBar) SetCallback(cb func()) *ProgressBar {
+	pb.callback = cb
+	return pb
 }
 
 // SetWidth sets the width of the progress bar.
@@ -288,6 +307,11 @@ func (pb *ProgressBar) Stop() {
 	pb.stopCh = make(chan interface{})
 	pb.active = false
 	fmt.Print("\r\033[K") // Clear line
+
+	// Execute callback if set
+	if pb.callback != nil {
+		pb.callback()
+	}
 }
 
 // Update sets the current progress percentage.


### PR DESCRIPTION
#### Summary
This PR adds an optional callback function to `Spinner` and `ProgressBar` components. If defined, the callback is executed automatically after `Stop`, allowing users to add custom actions upon animation completion.

#### Motivation
Custom callbacks improve flexibility by allowing users to trigger actions post-animation (e.g., logging, notifying users, cleanup logic) without additional code after every `Stop` call.

#### Example
```go
spinner := NewSpinner().SetCallback(func() {
	fmt.Println("Done!")
})
spinner.Start()
time.Sleep(3 * time.Second)
spinner.Stop() // Executes the callback
```

#### Benefits
- **Flexible Completion Handling**: Allows custom actions to run after animations stop.
- **Backwards Compatible**: Existing behavior remains unchanged if no callback is set.

Let me know if there are any adjustments you'd like to see. I'm open to feedback! :)